### PR TITLE
:bug: Fix a warning filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ python_files = [
     "*_test.py",
 ]
 filterwarnings = [
-    "ignore::DeprecationWarning:google._upb._message.MessageMapContainer",
-    "ignore::DeprecationWarning:google._upb._message.ScalarMapContainer"
+    "ignore:Type google._upb._message:DeprecationWarning"  # chromadb
 ]
 
 [build-system]


### PR DESCRIPTION
We get these warnings derived from `chromadb`'s dependency `protobuf` when running tests.
https://github.com/gomyway1216/rag/actions/runs/11194747846/job/31121612257
```
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 1 passed, 2 warnings in 2.08s =========================
```


This pull request fixes the warning filter to suppress the messages.
https://github.com/gomyway1216/rag/actions/runs/11247175098/job/31270209306?pr=34
```
============================= test session starts ==============================
platform linux -- Python 3.12.6, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/runner/work/rag/rag
configfile: pyproject.toml
plugins: anyio-4.6.0
collected 1 item

tests.py .                                                               [100%]

============================== 1 passed in 1.79s ===============================
```