### PR TITLE
added min_length to LearnRequest

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -60,7 +60,6 @@ def learn(learn_request: LearnRequest):
     SPLIT_INTO = 4  # Chunk size of quarter a paragraph is the best based on our preliminary experiment
 
     # input text should contain exactly one paragraph per line
-    # the input text length must be at least 4
     documents_paragraphs = learn_request.text.split("\n")
 
     for document_sequence in documents_paragraphs:

--- a/app/models.py
+++ b/app/models.py
@@ -10,7 +10,7 @@ class ChatResponse(BaseModel):
 
 
 class LearnRequest(BaseModel):
-    text: str = Field(description="The text to be learned by the chatbot")
+    text: str = Field(min_length=4, description="The text to be learned by the chatbot")
 
 
 class BMIRequest(BaseModel):

--- a/app/tests/api/routes/test_LearnRequest.py
+++ b/app/tests/api/routes/test_LearnRequest.py
@@ -1,17 +1,30 @@
 from fastapi.testclient import TestClient
 
 
-def test_LearnRequest1(client: TestClient):
+def test_learn_request_under_limit(client: TestClient):
     response = client.post(
         "/learn",
         json={
             "text": "dog",
         },
     )
+    print(response.json())
     assert response.status_code == 422
 
+    assert response.json() == {
+        "detail": [
+            {
+                "type": "string_too_short",
+                "loc": ["body", "text"],
+                "msg": "String should have at least 4 characters",
+                "input": "dog",
+                "ctx": {"min_length": 4},
+            }
+        ]
+    }
 
-def test_LearnRequest2(client: TestClient):
+
+def test_learn_request_right_on_inclusive_limit(client: TestClient):
     response = client.post(
         "/learn",
         json={
@@ -20,8 +33,12 @@ def test_LearnRequest2(client: TestClient):
     )
     assert response.status_code == 204
 
+    # assert response.json() == {"detail": [
+    #    {"loc": ["body", "text"], "msg": "String should have at least 4 characters", "input": "cats", "ctx": {"min_length": 4}}
+    # ]}
 
-def test_LearnRequest3(client: TestClient):
+
+def test_learn_request_one_sentence(client: TestClient):
     response = client.post(
         "/learn",
         json={
@@ -31,7 +48,17 @@ def test_LearnRequest3(client: TestClient):
     assert response.status_code == 204
 
 
-def test_LearnRequest4(client: TestClient):
+def test_learn_request_one_paragraph(client: TestClient):
+    response = client.post(
+        "/learn",
+        json={
+            "text": "The family on my father's side is descended from Caspar Keller, a native of Switzerland, who settled in Maryland. One of my Swiss ancestors was the first teacher of the deaf in Zurich and wrote a book on the subject of their education—rather a singular coincidence; though it is true that there is no king who has not had a slave among his ancestors, and no slave who has not had a king among his."
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_learn_request_few_paragraphs(client: TestClient):
     response = client.post(
         "/learn",
         json={

--- a/app/tests/api/routes/test_LearnRequest.py
+++ b/app/tests/api/routes/test_LearnRequest.py
@@ -8,7 +8,7 @@ def test_LearnRequest1(client: TestClient):
             "text": "dog",
         },
     )
-    assert response.status_code == 204
+    assert response.status_code == 422
 
 
 def test_LearnRequest2(client: TestClient):
@@ -39,5 +39,3 @@ def test_LearnRequest4(client: TestClient):
         },
     )
     assert response.status_code == 204
-
-

--- a/app/tests/api/routes/test_LearnRequest.py
+++ b/app/tests/api/routes/test_LearnRequest.py
@@ -8,9 +8,7 @@ def test_learn_request_under_limit(client: TestClient):
             "text": "dog",
         },
     )
-    print(response.json())
     assert response.status_code == 422
-
     assert response.json() == {
         "detail": [
             {
@@ -32,10 +30,6 @@ def test_learn_request_right_on_inclusive_limit(client: TestClient):
         },
     )
     assert response.status_code == 204
-
-    # assert response.json() == {"detail": [
-    #    {"loc": ["body", "text"], "msg": "String should have at least 4 characters", "input": "cats", "ctx": {"min_length": 4}}
-    # ]}
 
 
 def test_learn_request_one_sentence(client: TestClient):

--- a/app/tests/api/routes/test_LearnRequest.py
+++ b/app/tests/api/routes/test_LearnRequest.py
@@ -1,0 +1,43 @@
+from fastapi.testclient import TestClient
+
+
+def test_LearnRequest1(client: TestClient):
+    response = client.post(
+        "/learn",
+        json={
+            "text": "dog",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_LearnRequest2(client: TestClient):
+    response = client.post(
+        "/learn",
+        json={
+            "text": "cats",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_LearnRequest3(client: TestClient):
+    response = client.post(
+        "/learn",
+        json={
+            "text": "The family on my father's side is descended from Caspar Keller, a native of Switzerland, who settled in Maryland.",
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_LearnRequest4(client: TestClient):
+    response = client.post(
+        "/learn",
+        json={
+            "text": "The family on my father's side is descended from Caspar Keller, a native of Switzerland, who settled in Maryland. One of my Swiss ancestors was the first teacher of the deaf in Zurich and wrote a book on the subject of their education—rather a singular coincidence; though it is true that there is no king who has not had a slave among his ancestors, and no slave who has not had a king among his. \n My grandfather, Caspar Keller's son, \"entered\" large tracts of land in Alabama and finally settled there. I have been told that once a year he went from Tuscumbia to Philadelphia on horseback to purchase supplies for the plantation, and my aunt has in her possession many of the letters to his family, which give charming and vivid accounts of these trips. \n My Grandmother Keller was a daughter of one of Lafayette's aides, Alexander Moore, and granddaughter of Alexander Spotswood, an early Colonial Governor of Virginia. She was also second cousin to Robert E. Lee.",
+        },
+    )
+    assert response.status_code == 204
+
+


### PR DESCRIPTION
#95 
I added constraints on input to LearnRequest

It gives me 
`fastapi     | INFO:     192.168.65.1:45565 - "POST /learn HTTP/1.1" 422 Unprocessable Entity`
when I feed short sequences such as "dog" (less than 4 letters)